### PR TITLE
Add CLI options for user and group containers

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -2,13 +2,27 @@
 import os
 from pyad import adgroup
 
-def add_group(group_name: str, base_dir: str, logger):
-    """
-    Maakt een nieuwe AD-groep én een directory met groepseigenaar.
+def add_group(
+    group_name: str,
+    base_dir: str,
+    logger,
+    container_dn: str = "OU=Groups,DC=poliforma,DC=local",
+):
+    """Create a new AD group and corresponding directory.
+
+    Parameters
+    ----------
+    group_name: str
+        Name of the group to create.
+    base_dir: str
+        Directory path where the group's folder will be created.
+    logger
+        Logger instance for logging actions.
+    container_dn: str, optional
+        Distinguished name of the container where the group will be created.
     """
     # AD-groep
-    group = adgroup.ADGroup.create(group_name,
-                                   container_dn="OU=Groups,DC=poliforma,DC=local")
+    group = adgroup.ADGroup.create(group_name, container_dn=container_dn)
     logger.info(f"Nieuwe AD-groep {group_name} aangemaakt")
 
     # Directory

--- a/main.py
+++ b/main.py
@@ -16,11 +16,21 @@ def main():
     p.add_argument("firstname")
     p.add_argument("lastname")
     p.add_argument("group")
+    p.add_argument(
+        "--user-ou",
+        default="OU=pythonusers,DC=poliforma,DC=local",
+        help="Container DN for new users",
+    )
     # add others like --base-home, --servicedesk-tel als defaults
 
     # add-group
     r = sub.add_parser("add-group")
     r.add_argument("group_name")
+    r.add_argument(
+        "--group-ou",
+        default="OU=Groups,DC=poliforma,DC=local",
+        help="Container DN for new groups",
+    )
 
     # ... migratie en search-user voeg je op dezelfde wijze toe
 
@@ -31,11 +41,18 @@ def main():
     logger = configure_logger("ad_script.log")
 
     if args.cmd == "add-user":
-        user, home = add_user(args.username, args.firstname, args.lastname,
-                              args.group, "/srv/homes", logger)
+        user, home = add_user(
+            args.username,
+            args.firstname,
+            args.lastname,
+            args.group,
+            "/srv/homes",
+            logger,
+            container_dn=args.user_ou,
+        )
         write_summary(home, args.username, args.group, "+31 20 123 4567")
     elif args.cmd == "add-group":
-        add_group(args.group_name, "/srv/groups", logger)
+        add_group(args.group_name, "/srv/groups", logger, container_dn=args.group_ou)
     # ...
 
 if __name__ == "__main__":

--- a/users.py
+++ b/users.py
@@ -3,8 +3,35 @@ from pyad import aduser, adcontainer
 import os
 from directories import create_home_directory
 
-def add_user(username: str, firstname: str, lastname: str, group_dn: str, base_home: str, logger):
-    container = adcontainer.ADContainer.from_dn("OU=pythonusers,DC=poliforma,DC=local")
+def add_user(
+    username: str,
+    firstname: str,
+    lastname: str,
+    group_dn: str,
+    base_home: str,
+    logger,
+    container_dn: str = "OU=pythonusers,DC=poliforma,DC=local",
+):
+    """Create a new user in the specified container.
+
+    Parameters
+    ----------
+    username: str
+        Logon name for the new user.
+    firstname: str
+        Given name of the user.
+    lastname: str
+        Surname of the user.
+    group_dn: str
+        Distinguished name of the group for setting permissions on the home directory.
+    base_home: str
+        Base directory where the home folder will be created.
+    logger
+        Logger instance for logging actions.
+    container_dn: str, optional
+        Distinguished name of the container where the user will be created.
+    """
+    container = adcontainer.ADContainer.from_dn(container_dn)
 
     # Try removing an existing user to avoid naming conflicts
     try:


### PR DESCRIPTION
## Summary
- allow specifying user and group container DN via command line
- pass the container DN through to `add_user` and `add_group`
- update docstrings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9bc1d5ac832cbb96deab6c2b5417